### PR TITLE
[change] UMCP-136:  update composer dependency to secure php-sdk can …

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "Apache-2.0",
     "require": {
         "php": "~7.1.3|~7.2.0|~7.3.0|~7.4.0",
-        "unzerdev/php-sdk": "~1.1.0",
+        "unzerdev/php-sdk": ">=1.1.4.1 <1.2",
         "ext-json": "*"
     },
     "require-dev": {


### PR DESCRIPTION
Make sure, composer installs at least php-sdk in version 1.1.4.1 to ensure the correct cancel logic is used.